### PR TITLE
fix: sobrescrever objeto de mesma chave em put() com APAGADO no probing

### DIFF
--- a/java/src/tabelahash/TabelaHashEnderecamentoAberto.java
+++ b/java/src/tabelahash/TabelaHashEnderecamentoAberto.java
@@ -172,22 +172,35 @@ public class TabelaHashEnderecamentoAberto {
     private void put(Aluno[] tabela, Integer chave, Aluno valor) {
         int sondagem = 0;
         int hash;
+        int idxPut = -1;
         while (sondagem < tabela.length) {
 
             hash = (hash(chave) + sondagem) % tabela.length;
             Aluno tmpAluno = tabela[hash];
-            if (tmpAluno == null || 
-                    tmpAluno.getMatricula().equals(chave) ||
-                    tmpAluno.equals(APAGADO)) {
-                tabela[hash] = valor;
-                this.chaves.add(chave);
-                this.valores.add(valor);
-                this.size += 1;
-                return;
+
+            if(tmpAluno == null){
+                if(idxPut == -1){
+                    idxPut = hash;
+                }
+                break;
+            }
+            if (tmpAluno.getMatricula().equals(chave)) {
+                idxPut = hash;
+                break;
+            }
+            if(idxPut == -1 && tmpAluno.equals(APAGADO)){
+                idxPut = hash;
             }
 
             sondagem += 1;
 
+        }
+
+        if(idxPut != -1){
+            tabela[idxPut] = valor;
+            this.chaves.add(chave);
+            this.valores.add(valor);
+            this.size += 1;
         }
 
     }

--- a/java/src/tabelahash/TabelaHashEnderecamentoAberto.java
+++ b/java/src/tabelahash/TabelaHashEnderecamentoAberto.java
@@ -186,6 +186,7 @@ public class TabelaHashEnderecamentoAberto {
             }
             if (tmpAluno.getMatricula().equals(chave)) {
                 idxPut = hash;
+                this.size -= 1;
                 break;
             }
             if(idxPut == -1 && tmpAluno.equals(APAGADO)){


### PR DESCRIPTION
Altera o método ```put()``` para continuar a sondagem mesmo depois de encontrar um elemento ```APAGADO```, somente adicionando na sua posição se não for achado um objeto com a mesma chave para ser substituído.