### PR TITLE
refactor: siplify put method logic in chained hash table and remove code duplication

### DIFF
--- a/java/src/tabelahash/TabelaHashEncadeada.java
+++ b/java/src/tabelahash/TabelaHashEncadeada.java
@@ -71,18 +71,17 @@ public class TabelaHashEncadeada {
         
         if (alunos == null) {
             alunos = new ArrayList<Aluno>();
-            alunos.add(valor);
             this.tabela[hash] = alunos;
+        }
 
-        } else {
-            for (int i = 0; i < alunos.size(); i++) {
-                if (alunos.get(i).getMatricula() == chave) {
-                    alunos.set(i, valor);
-                    return;
-                }
+        for (int i = 0; i < alunos.size(); i++) {
+            if (alunos.get(i).getMatricula() == chave) {
+                alunos.set(i, valor);
+                return;
             }
-            alunos.add(valor);
-        }    
+        }
+            
+        alunos.add(valor);
     }
 
     /**


### PR DESCRIPTION
Refactor the put method in the chained hash table by removing the else block, as the for loop will never execute on the empty ArrayList, "alunos". Moreover, this change eliminates duplication by adding the value to the list only once, at the end of the method, since, if no duplicate is found, the insertion will occur in both cases. 

The refactored version improves code readability and follows to better programming practices.