### PR TITLE
fix: casos de tentativa de adição de elemento existente

### DIFF
--- a/java/src/bst/BST.java
+++ b/java/src/bst/BST.java
@@ -14,41 +14,39 @@ public class BST {
     }
     
     /**
-     * Implementação iterativa da adição de um elemento em uma árvore binária de pequisa.
+     * Implementação iterativa da adição de um elemento em uma árvore binária de pesquisa.
      * @param element o valor a ser adicionado na árvore.
      */
     public void add(int element) {
-        this.size += 1;
-        if (isEmpty())
+        if (isEmpty()) {
             this.root = new Node(element);
-        else {
-            
-            Node aux = this.root;
-            
-            while (aux != null) {
-                
-                if (element < aux.value) {
-                    if (aux.left == null) { 
-                        Node newNode = new Node(element);
-                        aux.left = newNode;
-                        newNode.parent = aux;
-                        return;
-                    }
-                    
-                    aux = aux.left;
-                } else {
-                    if (aux.right == null) { 
-                        Node newNode = new Node(element);
-                        aux.right = newNode;
-                        newNode.parent = aux;
-                        return;
-                    }
-                    
-                    aux = aux.right;
+            this.size = 1;
+            return;
+        }
+
+        Node aux = this.root;
+        while (true) {
+            if (element == aux.value)
+                return;
+
+            if (element < aux.value) {
+                if (aux.left == null) {
+                    aux.left = new Node(element);
+                    aux.left.parent = aux;
+                    this.size++;
+                    return;
                 }
+                aux = aux.left;
+            } else {
+                if (aux.right == null) {
+                    aux.right = new Node(element);
+                    aux.right.parent = aux;
+                    this.size++;
+                    return;
+                }
+                aux = aux.right;
             }
         }
-        
     }
     
     
@@ -143,16 +141,15 @@ public class BST {
      * Implementação recursiva do método de adição.
      * @param element elemento a ser adicionado.
      */
-    public void recursiveAdd(int element) {
-        
-        if (isEmpty())
+    public void recursiveAdd(int element) { 
+        if (isEmpty()) {
             this.root = new Node(element);
-        else {
-            Node aux = this.root;
-            recursiveAdd(aux, element);
+            this.size = 1;
+        } else {
+            if (recursiveAdd(this.root, element)) {
+                this.size++;
+            }
         }
-        this.size += 1;
-        
     }
 
     /**
@@ -160,24 +157,27 @@ public class BST {
      * @param node a raíz da árvore.
      * @param element elemento a ser adicionado.
      */
-    private void recursiveAdd(Node node, int element) {
-        
+    private boolean recursiveAdd(Node node, int element) {
+        if (element == node.value) {
+            return false;
+        }
+
         if (element < node.value) {
             if (node.left == null) {
                 Node newNode = new Node(element);
                 node.left = newNode;
                 newNode.parent = node;
-                return;
+                return true;
             }
-            recursiveAdd(node.left, element);
+            return recursiveAdd(node.left, element);
         } else {
             if (node.right == null) {
                 Node newNode = new Node(element);
                 node.right = newNode;
                 newNode.parent = node;
-                return;
+                return true;
             }
-            recursiveAdd(node.right, element);
+            return recursiveAdd(node.right, element);
         }
         
     }

--- a/java/src/bst/BSTTest.java
+++ b/java/src/bst/BSTTest.java
@@ -127,4 +127,24 @@ public class BSTTest {
         assertEquals(bst.size(), 1);
 
     }
+    @Test
+    public void testAdicionaDuplicadas() {
+        BST bst = new BST();
+        bst.add(50);
+        bst.add(30);
+        bst.add(80);
+        bst.add(20);
+        bst.add(40);
+        int tamanhoInicial = bst.size();
+        ArrayList<Integer> bfsAntes = bst.bfs();
+
+        assertEquals(5, tamanhoInicial);
+
+        bst.add(50);
+        bst.add(20);
+        bst.add(30);
+
+        assertEquals("O tamanho da árvore não deveria mudar ao adicionar duplicadas", tamanhoInicial, bst.size());
+        assertEquals("A estrutura da árvore não deveria mudar ao adicionar duplicadas", bfsAntes, bst.bfs());
+    }
 }


### PR DESCRIPTION
Por padrão a BST não deve permitir elementos duplicados, isso foi fixado, além disso fiz com que o método recursiveAdd retorne um booleano para que possamos fazer o check de duplicadas durante a execução da adição, gerando uma complexidade de O(H) onde H é a altura da árvore ao invés de O(2.H) que também é O(H) mas com maior custo computacional, também adicionei testes para garantir que a estrutura da árvore não muda durante a tentativa de adição de repetidas,tanto o método recursivo como o iterativo foram fixados (pequeno typo fix também).


<img width="1192" height="655" alt="BstTree" src="https://github.com/user-attachments/assets/c1144789-ce38-4a27-b55a-16145a9098fd" />

Segue em anexo um exemplo do problema, não podemos permitir a adição desse node (20), se não perderiamos a propriedade que faz com que possamos fazer operação em O(log n)