### PR TITLE
fix: update parent reference of transferred child in rotations

### DIFF
--- a/java/src/avl/AVL.java
+++ b/java/src/avl/AVL.java
@@ -180,6 +180,11 @@ public class AVL {
         newRoot.parent = node.parent;
 
         node.left = newRoot.right;
+
+        if (newRoot.right != null) {
+            newRoot.right.parent = node;
+        }
+
         newRoot.right = node;
 
         node.parent = newRoot;
@@ -203,6 +208,11 @@ public class AVL {
         newRoot.parent = node.parent;
 
         node.right = newRoot.left;
+
+        if (newRoot.left != null) {
+            newRoot.left.parent = node;
+        }
+
         newRoot.left = node;
 
         node.parent = newRoot;


### PR DESCRIPTION
## Problema
Durante a execução da rotação à esquerda e à direta, a subárvore do novo nó raiz  é transferida para ser o novo filho do nó rotacionado.  No entanto, o ponteiro `.parent` do nó transferido não estava sendo atualizado. Como consequência, o filho apontava para o pai antigo.

## Correção
Adicionada a verificação para atualizar o ponteiro `.parent` do nó adotado caso ele não seja nulo.

```java
if (newRoot.left != null) {
    newRoot.left.parent = node;
}

if (newRoot.right != null) {
    newRoot.right.parent = node;
}